### PR TITLE
Some small fixes and improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prettify-check": "prettier --check \"./{src,__{tests,mocks}__}/**/*.{ts,js}\"",
     "yarn:import": "rm -rf ./yarn.lock && yarn import"
   },
+  "typings": "./dist/index.d.ts",
   "keywords": [
     "Google Ads",
     "Google Adwords",

--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ async function getByPage() {
     startIndex: 0,
     numberResults: 2,
   };
-  const actualValue = await budgetService.getByPage(paging);
+  return await budgetService.getByPage(paging);
 }
 ```
 
@@ -119,7 +119,7 @@ async function createBudget() {
     status: Budget.BudgetStatus.ENABLED,
   };
 
-  const actualValue = await budgetService.add(budget);
+  return await budgetService.add(budget);
 }
 ```
 
@@ -131,7 +131,7 @@ async function getCampaignsByPages() {
     startIndex: 0,
     numberResults: 1,
   };
-  const actualValue = await campaignService.getByPage(paging);
+  return await campaignService.getByPage(paging);
 }
 ```
 

--- a/src/services/adwords/AdWordsService.ts
+++ b/src/services/adwords/AdWordsService.ts
@@ -95,7 +95,7 @@ class AdWordsService {
     const url = `${xmlns}/${serviceName}${AdWordsService.suffix}`;
     const verbose = _.get(options, ['verbose'], this.verbose);
 
-    this.soapHeader.clientCustomerId = options ? options.clientCustomerId : this.soapHeader.clientCustomerId;
+    this.soapHeader.clientCustomerId = (options && options.clientCustomerId) ? options.clientCustomerId : this.soapHeader.clientCustomerId;
     this.soapHeader.partialFailure = !!(options ? options.partialFailure : this.soapHeader.partialFailure);
     let soapServiceOptions: ISoapServiceOpts = {
       authService: this.authService,


### PR DESCRIPTION
Without this check passing `{ verbose: false }` will set undefined to the **clientCustomerId**.